### PR TITLE
Add dashboard for power automate operations

### DIFF
--- a/default/data/ui/nav/default.xml
+++ b/default/data/ui/nav/default.xml
@@ -4,6 +4,7 @@
   <view name="login_activity" />
   <view name="oauth_abuse" />
   <view name="other_suspicious_activity" />
+  <view name="flow_rules"/>
   <collection label="Investigator toolkit">
     <view name="account_investigator_ai" />
     <view name="forwarding_rule_investigator" />

--- a/default/data/ui/views/flow_rules.xml
+++ b/default/data/ui/views/flow_rules.xml
@@ -1,0 +1,107 @@
+<form theme="dark" version="1.1">
+    <label>Power Automate Flow Rules</label>
+    <fieldset submitButton="false">
+      <input type="time" token="field1" searchWhenChanged="true">
+        <label>Select Timeperiod:</label>
+        <default>
+          <earliest>-24h@h</earliest>
+          <latest>now</latest>
+        </default>
+      </input>
+    </fieldset>
+    <row>
+      <panel>
+        <html>
+          <p> Users can setup or modify Flow rules within the O365 Power Automate functionality.  This overview mainly tracks the following Power Automate Flow operations:</p>
+          <ul>
+            <li>
+              <b>CancelFlowRun</b>
+            </li> 
+            <li>
+              <b>CreateConnection</b>
+            </li>
+            <li>
+              <b>CreateFlow</b>
+            </li>
+            <li>
+              <b>DeleteFlow</b>
+            </li>
+            <li>
+              <b>GetApi</b>
+            </li>
+            <li>
+              <b>GetFlow</b>
+            </li>
+            <li>
+              <b>AdminGetFlow</b>
+            </li>
+            <li>
+              <b>ListCallbackUrl</b>
+            </li>
+            <li>
+              <b>ListApis</b>
+            </li>
+            <li>
+              <b>ListFlowOwners</b>
+            </li>
+            <li>
+              <b>ModifyFlowOwners</b>
+            </li>
+            <li>
+              <b>AdminModifyFlowOwners</b>
+            </li>
+            <li>
+              <b>ModifyRunOnlyUsers</b>
+            </li>
+            <li>
+              <b>UpdateFlow</b>
+            </li>
+          </ul>
+             
+          <p> 
+            <i>Please note that only Cloud Flows actions are logged within the Microsoft Compliance Center, and Desktop Flows logs need to be gathered seperately. For more information see:https://docs.microsoft.com/en-us/power-platform/admin/logging-power-automate</i>
+          </p>
+          <p>
+            <i>For more information on Flow Management see:https://docs.microsoft.com/en-us/connectors/flowmanagement/</i>
+          </p>
+           <p>
+            <i>For more information regarding Power Automate loggin: https://docs.microsoft.com/en-us/power-platform/admin/logging-power-automate</i>
+          </p>
+        </html>
+      </panel>
+    </row>
+    <row>
+      <panel>
+        <title>Number of Flow rules in this dataset</title>
+        <single>
+          <search>
+            <query>`ual` eventtype="flow_rules" |stats count</query>
+            <earliest>$field1.earliest$</earliest>
+            <latest>$field1.latest$</latest>
+            <sampleRatio>1</sampleRatio>
+          </search>
+          <option name="colorBy">value</option>
+          <option name="colorMode">block</option>
+          <option name="drilldown">all</option>
+          <option name="numberPrecision">0</option>
+          <option name="rangeColors">["0x53a051","0xf8be34","0xf1813f","0xdc4e41"]</option>
+          <option name="rangeValues">[0,5,10]</option>
+          <option name="refresh.display">progressbar</option>
+          <option name="showSparkline">1</option>
+          <option name="showTrendIndicator">1</option>
+          <option name="trellis.enabled">0</option>
+          <option name="trellis.scales.shared">1</option>
+          <option name="trellis.size">medium</option>
+          <option name="trendColorInterpretation">standard</option>
+          <option name="trendDisplayMode">absolute</option>
+          <option name="unitPosition">after</option>
+          <option name="useColors">1</option>
+          <option name="useThousandSeparators">1</option>
+          <drilldown>
+            <link target="_blank">search?q=%60ual%60%20eventtype=%22flow_rules%22%20%20%7C%20spath%20input=AuditData&amp;earliest=0&amp;latest=</link>
+          </drilldown>
+        </single>
+      </panel>
+    </row>
+  </form>
+  

--- a/default/data/ui/views/flow_rules.xml
+++ b/default/data/ui/views/flow_rules.xml
@@ -12,50 +12,29 @@
     <row>
       <panel>
         <html>
-          <p> Users can setup or modify Flow rules within the O365 Power Automate functionality.  This overview mainly tracks the following Power Automate Flow operations:</p>
+          <p> Users can setup or modify Flow rules within the O365 Power Automate functionality. These rules allow an attacker to create persistent triggers/flows which, for example, allow them to exfiltrate O365 data. This dashboard tracks Power Automate Flow log entries with the following "Operation" syntax:</p>
           <ul>
             <li>
-              <b>CancelFlowRun</b>
+              <b>*Flow (e.g. CreateFlow)</b>
+            </li> 
+            <li>
+              <b>*FlowRun (e.g. CancelFlowRun)</b>
+            </li> 
+            <li>
+              <b>*FlowOwners (e.g. ModifyFlowOwners)</b>
+            </li> 
+            <li>
+              <b>ModifyRunOnlyUsers</b>
             </li> 
             <li>
               <b>CreateConnection</b>
-            </li>
-            <li>
-              <b>CreateFlow</b>
-            </li>
-            <li>
-              <b>DeleteFlow</b>
-            </li>
-            <li>
-              <b>GetApi</b>
-            </li>
-            <li>
-              <b>GetFlow</b>
-            </li>
-            <li>
-              <b>AdminGetFlow</b>
-            </li>
+            </li> 
             <li>
               <b>ListCallbackUrl</b>
-            </li>
+            </li> 
             <li>
-              <b>ListApis</b>
-            </li>
-            <li>
-              <b>ListFlowOwners</b>
-            </li>
-            <li>
-              <b>ModifyFlowOwners</b>
-            </li>
-            <li>
-              <b>AdminModifyFlowOwners</b>
-            </li>
-            <li>
-              <b>ModifyRunOnlyUsers</b>
-            </li>
-            <li>
-              <b>UpdateFlow</b>
-            </li>
+              <b>GetApi</b>
+            </li> 
           </ul>
              
           <p> 

--- a/default/eventtypes.conf
+++ b/default/eventtypes.conf
@@ -76,3 +76,12 @@ search = Operation=MailItemsAccessed OR Operations=MailItemsAccessed
 
 [file_activity]
 search = Operation=File* OR Operations=File*
+
+[flow_rules]
+search = Operation=*Flow OR Operations=*Flow OR\
+Operation=*FlowRun OR Operations=*FlowRun OR\
+Operation=*FlowOwners OR Operations=*FlowOwners OR\
+Operation=ModifyRunOnlyUsers OR Operations=ModifyRunOnlyUsers OR\
+Operation=CreateConnection OR Operations=CreateConnection OR\
+Operation=ListCallbackUrl OR Operations=ListCallbackUrl OR\
+Operation=GetApi OR Operations=GetApi


### PR DESCRIPTION
Currently the app does not track log operations for Power Automate Flows. 

An attacker might create or edit Flows to gain some persistence. within O365. For example, an attacker could create a flow which synchronises shared documents to an attacker-drive, or they could forward mail contents to an attacker-controlled account.

The dashboard should keep track of all sensitive Powerflow operations ([taken from here](https://docs.microsoft.com/en-us/connectors/flowmanagement/#actions))

I'm always open for improvement suggestions or changes

Greetings Timo